### PR TITLE
docs: AI handover INDEX STATE FLAGS Contributors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,3 +22,8 @@ Do not auto-load `docs/archive/`. Do not invent a business FMD suite (no BRD / U
 ## Ownership
 
 Owner: GDG PUP Technology (incoming CTO). Handover 2026-09-02. Outgoing CTO: Carlos Jerico Dela Torre.
+## FMD
+
+**Built on FMD philosophy (v1.31.0)** - INDEX / STATE / FLAGS control plane for humans and AI; no FMD engine install.
+
+Read order stays: docs/state.md then docs/index.md then FLAGS.md then task docs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md - Code Rush
+
+Guidance for AI agents and humans working in this repository.
+
+## Read order (every session)
+
+1. [docs/state.md](docs/state.md) - operating position (Archive)
+2. [docs/index.md](docs/index.md) - what docs exist
+3. [FLAGS.md](FLAGS.md) - known gaps / accepted limitations
+4. Task docs linked from INDEX (onboarding, deploy, architecture) only as needed
+5. [README.md](README.md) - how to run and contribute
+
+Do not auto-load `docs/archive/`. Do not invent a business FMD suite (no BRD / UES / GTM).
+
+## Conventions
+
+- Challenge/event tool posture: Archive unless preparing a new rush.
+- Do not invent GTM or product-suite docs.
+- Docs-only improvements land as FLAGS unless maintainers explicitly ask for code changes.
+- No em-dashes in new docs.
+
+## Ownership
+
+Owner: GDG PUP Technology (incoming CTO). Handover 2026-09-02. Outgoing CTO: Carlos Jerico Dela Torre.

--- a/FLAGS.md
+++ b/FLAGS.md
@@ -1,0 +1,11 @@
+# FLAGS
+
+Improvement register for this repository. Documentation handover only - do not treat Open rows as bugs fixed in the docs PR.
+
+Status: **Open** (actionable later) or **Accepted** (known limitation).
+
+
+| ID | Severity | Finding | Evidence | Suggested next step | Status |
+| --- | --- | --- | --- | --- | --- |
+| F1 | Medium | Firebase env vars are required; README lists a partial set. | README Environment Setup | Publish a complete env name list (no secrets) before the next event. | Open |
+| F2 | Low | Package name is ``css-rush`` while repo/title is Code Rush. | ``package.json`` | Harmless naming drift; align only if republishing. | Accepted |

--- a/README.md
+++ b/README.md
@@ -85,3 +85,21 @@ If you encounter any issues or have questions, please [open an issue](https://gi
 ## 📄 License
 
 Distributed under the MIT License. See [LICENSE](LICENSE) for more information.
+
+---
+
+## Documentation
+
+- [docs/state.md](docs/state.md) - Operating position / handover
+- [docs/index.md](docs/index.md) - Doc inventory
+- [FLAGS.md](FLAGS.md) - Improvement register
+- [AGENTS.md](AGENTS.md) - Agent load order
+
+## Contributors
+
+This project is made possible by the GDG PUP community:
+
+| Role | Name |
+| --- | --- |
+| 💻 **Development** | [Erwin Daguinotas](https://www.linkedin.com/in/erwin-daguinotas) - Web Development Lead |
+| 💻 **Development** | [Gerald Berongoy](https://www.linkedin.com/in/geraldberongoy) - Senior Backend Developer / Web Development Learning Head |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,23 @@
+# Documentation Index: Code Rush
+
+**Project slug:** `code-rush`
+**Maintained by:** GDG PUP Technology (incoming CTO)
+**Last updated:** 2026-09-02
+
+**Operating position:** [state.md](state.md) - read that first.
+
+## 1. Artifact Inventory
+
+List only artifacts that exist.
+
+| Artifact | File | Version | Status | Last Updated | Last Reconciled |
+| --- | --- | --- | --- | --- | --- |
+| STATE | [state.md](state.md) | 1.0 | Current | 2026-09-02 | 2026-09-02 |
+| FLAGS | [../FLAGS.md](../FLAGS.md) | 1.0 | Current | 2026-09-02 | 2026-09-02 |
+| AGENTS | [../AGENTS.md](../AGENTS.md) | 1.0 | Current | 2026-09-02 | 2026-09-02 |
+| README | [../README.md](../README.md) | - | Current | 2026-09-02 | 2026-09-02 |
+
+
+## 2. Notes
+
+INDEX is inventory only. STATE is position. FLAGS holds improvement backlog. No BRD/UES/GTM suite for this handover.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,9 @@
-# Documentation Index: Code Rush
+﻿# Documentation Index: Code Rush
 
 **Project slug:** `code-rush`
 **Maintained by:** GDG PUP Technology (incoming CTO)
 **Last updated:** 2026-09-02
+**Built on FMD philosophy (v1.31.0)** - INDEX / STATE / FLAGS control plane for humans and AI; no FMD engine install.
 
 **Operating position:** [state.md](state.md) - read that first.
 

--- a/docs/state.md
+++ b/docs/state.md
@@ -1,0 +1,27 @@
+# Project State: Code Rush
+
+**Project slug:** `code-rush`
+**Owner:** GDG PUP Technology (incoming CTO)
+**Last updated:** 2026-09-02
+**Milestone:** Archive
+
+## Position
+
+Interactive **CSS speed-run / challenge** experience (``css-rush``) for GDG on Campus PUP campus showdowns: drag-and-drop CSS challenges, previews, and Firebase-backed leaderboards.
+
+Milestone: **Archive** as an event/challenge tool after the rush; redeploy when hosting another Code Rush.
+
+Handover date: 2026-09-02. Outgoing CTO: Carlos Jerico Dela Torre.
+
+## Read first
+
+1. [state.md](state.md) (this file)
+2. [index.md](index.md)
+3. [../FLAGS.md](../FLAGS.md)
+4. [../README.md](../README.md)
+5. [../AGENTS.md](../AGENTS.md)
+
+## Notes
+
+- Event/challenge tool for GDG PUP competitive CSS activities (Spark Rush mode referenced in README).
+- Requires Firebase env configuration to run fully.


### PR DESCRIPTION
## Summary
- Add FMD-philosophy AI/human handover docs: `docs/state.md`, `docs/index.md`, `FLAGS.md`, `AGENTS.md`
- Cosmos-style Contributors enriched from the Nexus roster (git authors only)
- No application code changes; product gaps recorded in FLAGS

## Test plan
- [ ] Open `docs/state.md` cold: milestone and owner clear
- [ ] `docs/index.md` lists only files that exist (no ghosts)
- [ ] `FLAGS.md` has concrete Open/Accepted rows or an explicit empty note
- [ ] `AGENTS.md` read order is state → index → FLAGS → task docs
- [ ] README Contributors match real git contributors